### PR TITLE
Add class name to element for added input padding

### DIFF
--- a/list.php
+++ b/list.php
@@ -66,6 +66,14 @@ class ListField extends BaseField {
     return tpl::load(__DIR__ . DS . 'template.php', array('field' => $this));
 
   }
+  
+  public function element() {
+
+    $element = parent::element();
+    $element->addClass('field-with-icon');
+    return $element;
+
+  }
 
   public function result() {
 


### PR DESCRIPTION
This fixes issue #2.

The added class name to the wrapping field element, adds padding to the input field. This prevents the input text to getting hidden under the input icon.

Instead of editing the css file for this fix, I used the same approach as the core Info field does:
https://github.com/getkirby/panel/blob/master/app/fields/info/info.php#L11-L15
